### PR TITLE
Update sci link in the template

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -20,7 +20,7 @@ tags:
 ## SCI Impact
 
 `SCI = (E * I) + M per R`  
-[Sofware Carbon Intensity Spec](https://github.com/Green-Software-Foundation/software_carbon_intensity)
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 [PATTERN_SCI_IMPACT]
 


### PR DESCRIPTION
Assim suggested to update the SCI link to the shortlink. This link will eventually be changed to something nicer in the future.

Reference: https://github.com/Green-Software-Foundation/green-software-patterns/pull/90#discussion_r986704044