### PR TITLE
Update existing Catalog Patterns to include SCI link

### DIFF
--- a/docs/catalog/cloud/cache-static-data.md
+++ b/docs/catalog/cloud/cache-static-data.md
@@ -23,6 +23,7 @@ Caching static data, such as images or audio, instead of transferring it over th
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation. Reducing the distance will impact two parts:
 

--- a/docs/catalog/cloud/choose-region-closest-to-users.md
+++ b/docs/catalog/cloud/choose-region-closest-to-users.md
@@ -19,6 +19,7 @@ Choose a region that is the closest to the majority of where the network packets
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation. Reducing the distance will impact two parts:
 

--- a/docs/catalog/cloud/compress-transmitted-data.md
+++ b/docs/catalog/cloud/compress-transmitted-data.md
@@ -19,6 +19,7 @@ Minimise the size of data transmitted by compressing files or payloads.
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation. Reducing the distance will impact two parts:
 

--- a/docs/catalog/cloud/delete-unused-storage-resources.md
+++ b/docs/catalog/cloud/delete-unused-storage-resources.md
@@ -19,6 +19,7 @@ Delete any unused storage resource.
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation. Deleting storage volumes will impact one part:
 - `M`: By reducing the total number of storage volumes required, we reduce the total embodied carbon.

--- a/docs/catalog/cloud/match-utilization-requirements-of-vm.md
+++ b/docs/catalog/cloud/match-utilization-requirements-of-vm.md
@@ -22,6 +22,7 @@ Rightsize your VMs by changing the number of resources allocated to a VM to matc
 ## SCI Impact
 
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 With respect to the SCI equation. Rightsizing oversized VMs will impact two parts:
 

--- a/docs/catalog/cloud/match-utilization-requirements-with-pre-configured-server.md
+++ b/docs/catalog/cloud/match-utilization-requirements-with-pre-configured-server.md
@@ -22,6 +22,7 @@ Rightsize your machine by selecting a pre-configured server that better matches 
 ## SCI Impact
 
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 With respect to the SCI equation. Rightsizing oversized VMs will impact two parts:
 

--- a/docs/catalog/cloud/optimise-storage-resource-utilisation.md
+++ b/docs/catalog/cloud/optimise-storage-resource-utilisation.md
@@ -22,6 +22,7 @@ Move storage resources away from underutilised storage resources.
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation. Moving storage resources will impact two parts:
 

--- a/docs/catalog/cloud/reduce-transmitted-data.md
+++ b/docs/catalog/cloud/reduce-transmitted-data.md
@@ -19,6 +19,7 @@ Minimise the size of data transmitted by only sending properties or values deeme
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation. Reducing the size of data will impact one part:
 

--- a/docs/catalog/cloud/set-retention-policy-on-storage-resources.md
+++ b/docs/catalog/cloud/set-retention-policy-on-storage-resources.md
@@ -19,6 +19,7 @@ Set a retention policy on storage resources to automate the deletion of unused s
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Sofware Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation. Setting retention policy will impact one part:
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -28,7 +28,7 @@ A green software pattern if applied correctly will reduce the emissions of your 
 
 Whether you are proposing a new pattern or a change to an existing pattern. The first step is to discuss the change with others.
 
-Open a GitHub issue https://github.com/Green-Software-Foundation/green-software-patterns/issues to discuss your changes.
+Open a [GitHub issue](https://github.com/Green-Software-Foundation/green-software-patterns/issues) to discuss your changes.
 
 Use the appropriate GitHub issue template for the change you would like to make.
 


### PR DESCRIPTION
## Description
As outlined in https://github.com/Green-Software-Foundation/green-software-patterns/issues/94, this PR simply deals with adding to/updating existing patterns in the catalog to include the SCI link - to be consistent with the updated `TEMPLATE.md` (https://github.com/Green-Software-Foundation/green-software-patterns/pull/92).

It also makes a small change to a link in the guide docs. 

--- 
It was suggested [here](https://github.com/Green-Software-Foundation/green-software-patterns/pull/90#discussion_r986704044) to potentially place this link more generally around the site, but I'm not sure exactly where that would be, so moved forward with the currently desired approach.

Also, I completely understand the concern about redundancy of the link if its included on every pattern, however at the same time, including it somewhere on all patterns may be useful for discovery.

In future, if patterns are being sent to developers who are seeing these concepts/this project for the first time (as resources, or in the same way one might send an article/blog/SO post), having this presented to them up-front could be a good way to make sure they make contact with that material as easily & soon as possible. Just some thoughts 😄 

## Related Issue
Closes https://github.com/Green-Software-Foundation/green-software-patterns/issues/94 



