### PR TITLE
134 display the sci equation consistently in patterns

### DIFF
--- a/docs/catalog/ai/energy-efficent-framework.md
+++ b/docs/catalog/ai/energy-efficent-framework.md
@@ -22,6 +22,7 @@ Evaluate and select energy efficient framework/module for AI/ML development, tra
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Software Carbon Intensity Spec](https://grnsft.org/sci)
 
 For the SCI equation, selecting an energy-efficient AI/ML would impact the following:
 - 'E': Having an energy efficient framework would reduce the energy consumption for your AI/ML training and inference and consequently, the E number should decrease.

--- a/docs/catalog/ai/pre-trained-transfer-learning.md
+++ b/docs/catalog/ai/pre-trained-transfer-learning.md
@@ -21,6 +21,7 @@ Evaluate and select pre-trained models and use transfer learning to avoid traini
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Software Carbon Intensity Spec](https://grnsft.org/sci)
 
 For the SCI equation, going with a pre-trained model would impact the following:
 - 'E': Having a pre-trained model would reduce the energy consumption for your AI/ML training as you don’t need to train the entire model from scratch and consequently, the E number should decrease.

--- a/docs/catalog/ai/right-hardware-type.md
+++ b/docs/catalog/ai/right-hardware-type.md
@@ -10,7 +10,7 @@ tags:
  - size:small
 ---
 
-# Select the right hardware/VM instance types for training and inference of AI/ML process. 
+# Select the right hardware/VM instance types for training and inference of AI/ML process
 
 ## Description
 Training an AI model has a significant carbon footprint. Selecting the right hardware/VM instance types for training the AI model is one of the choices you should make as part of your energy-efficient AI/ML process. For instance, custom application-specific integrated circuits (ASICs) and Field-programmable gate arrays (FPGAs) are provided or supported by cloud vendors which provide better energy efficiency and inference for AI models than conventional chips. 

--- a/docs/catalog/ai/right-hardware-type.md
+++ b/docs/catalog/ai/right-hardware-type.md
@@ -21,6 +21,7 @@ Evaluate and leverage the right hardware/VM instance types for training and infe
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Software Carbon Intensity Spec](https://grnsft.org/sci)
 
 For the SCI equation, the right hardware/VM types will impact the following:
 - 'E': Right hardware/VM type would provide better energy efficiency and inference for AI models. This should reduce the energy consumption of your AI/ML processes, and consequently, the E number should decrease.

--- a/docs/catalog/cloud/cache-static-data.md
+++ b/docs/catalog/cloud/cache-static-data.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Cache Static Data
+# Cache static data
 
 <PatternComponent></PatternComponent>
 

--- a/docs/catalog/cloud/choose-region-closest-to-users.md
+++ b/docs/catalog/cloud/choose-region-closest-to-users.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Choose A Region That Is Closest To Users
+# Choose a region that is closest to users
 
 ## Description
 From an energy-efficiency perspective, it's better to shorten the distance a network packet travels so that less energy is required to transmit it. Similarly, from an embodied-carbon perspective, when a network packet traverses through less computing equipment, we are more efficient with hardware. 

--- a/docs/catalog/cloud/compress-transmitted-data.md
+++ b/docs/catalog/cloud/compress-transmitted-data.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Compress Transmitted Data
+# Compress transmitted data
 
 ## Description
 From an energy-efficiency perspective, it's better to minimise the size of the data transmitted so that less energy is required because the network traffic is reduced. 

--- a/docs/catalog/cloud/delete-unused-storage-resources.md
+++ b/docs/catalog/cloud/delete-unused-storage-resources.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Delete Unused Storage Resources
+# Delete unused storage resources
 
 ## Description
 From an embodied carbon perspective, it's better to delete unused storage resources, so we are efficient with hardware and that the storage layer is optimised for the task. 

--- a/docs/catalog/cloud/match-utilization-requirements-of-vm.md
+++ b/docs/catalog/cloud/match-utilization-requirements-of-vm.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Match Utilization Requirements of Virtual Machines (VMs)
+# Match utilization requirements of virtual machines (VMs)
 
 ## Description
 

--- a/docs/catalog/cloud/match-utilization-requirements-with-pre-configured-server.md
+++ b/docs/catalog/cloud/match-utilization-requirements-with-pre-configured-server.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Match Utilization Requirements With Pre-Configured Servers
+# Match utilization requirements with pre-configured servers
 
 ## Description
 

--- a/docs/catalog/cloud/optimise-storage-resource-utilisation.md
+++ b/docs/catalog/cloud/optimise-storage-resource-utilisation.md
@@ -10,7 +10,7 @@ tags:
  - size:small
 ---
 
-# Optimize Storage Utilization
+# Optimize storage utilization
 
 ## Description
 From both an embodied carbon angle and an energy proportionality angle, it's better to maximise storage utilisation so the storage layer is optimised for the task. 

--- a/docs/catalog/cloud/optimize-avg-cpu-utilization.md
+++ b/docs/catalog/cloud/optimize-avg-cpu-utilization.md
@@ -12,7 +12,7 @@ tags:
  - size:medium
 ---
 
-# Optimize Average CPU Utilization
+# Optimize average CPU utilization
 
 ## Description
 

--- a/docs/catalog/cloud/optimize-peak-cpu-utilization.md
+++ b/docs/catalog/cloud/optimize-peak-cpu-utilization.md
@@ -12,7 +12,7 @@ tags:
  - size:medium
 ---
 
-# Optimize Peak CPU Utilization
+# Optimize peak CPU utilization
 
 ## Description
 

--- a/docs/catalog/cloud/reduce-transmitted-data.md
+++ b/docs/catalog/cloud/reduce-transmitted-data.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Reduce Transmitted Data
+# Reduce transmitted data
 
 ## Description
 From an energy-efficiency perspective, it's better to minimise the size of the data transmitted so that less energy is required because the network traffic is reduced. 

--- a/docs/catalog/cloud/set-retention-policy-on-storage-resources.md
+++ b/docs/catalog/cloud/set-retention-policy-on-storage-resources.md
@@ -9,7 +9,7 @@ tags:
  - size:small
 ---
 
-# Set Storage Retention Policies
+# Set storage retention policies
 
 ## Description
 From an embodied carbon perspective, it's better to have an automated mechanism to delete unused storage resources so we are efficient with hardware and that the storage layer is optimised for the task. 

--- a/docs/catalog/cloud/shed-lower-priority-traffic.md
+++ b/docs/catalog/cloud/shed-lower-priority-traffic.md
@@ -13,7 +13,7 @@ tags:
  - size:large
 ---
 
-# Shed Lower Priority Traffic
+# Shed lower priority traffic
 
 ## Description
 
@@ -28,8 +28,8 @@ From a hardware efficiency perspective, shedding lower priority traffic during h
 
 ## SCI Impact
 
-`SCI = (E * I) + M per R`  
-[Sofware Carbon Intensity Spec](https://github.com/Green-Software-Foundation/software_carbon_intensity)
+`SCI = (E * I) + M per R`
+[Software Carbon Intensity Spec](https://grnsft.org/sci)
 
 Concerning the SCI equation, optimizing peak CPU utilization will impact two parts:
 

--- a/docs/catalog/web/avoid-chaining-critical-requests.md
+++ b/docs/catalog/web/avoid-chaining-critical-requests.md
@@ -9,7 +9,7 @@ tags:
  - size:medium
 ---
 
-# Avoid Chaining Critical Requests
+# Avoid chaining critical requests
 
 ## Description
 

--- a/docs/catalog/web/avoid-tracking-unnecessary-data.md
+++ b/docs/catalog/web/avoid-tracking-unnecessary-data.md
@@ -10,7 +10,7 @@ tags:
  - size:small
 ---
 
-# Avoid Tracking Unnecessary Data
+# Avoid tracking unnecessary data
 
 ## Description
 

--- a/docs/catalog/web/defer-offscreen-images.md
+++ b/docs/catalog/web/defer-offscreen-images.md
@@ -10,7 +10,7 @@ tags:
 
 ---
 
-# Defer Offscreen Images
+# Defer offscreen images
 
 
 ## Description

--- a/docs/catalog/web/minify-web-assets.md
+++ b/docs/catalog/web/minify-web-assets.md
@@ -19,6 +19,7 @@ Minify web assets to reduce page size and network bandwidth while delivering the
 
 ## SCI Impact
 `SCI = (E * I) + M per R`
+[Software Carbon Intensity Spec](https://grnsft.org/sci)
 
 For the SCI equation, minifying web assets will impact the following::
 - 'E': Minifying  web assets would reduce the size of the web page and lead to reduction in network bytes during transfer of content. The browser/device would take less energy to render the content. This should reduce the energy consumption of your web page, and consequently, the E number should decrease.

--- a/docs/catalog/web/serve-images-in-modern-formats.md
+++ b/docs/catalog/web/serve-images-in-modern-formats.md
@@ -9,7 +9,7 @@ tags:
  - role:web-developer
 ---
 
-# Serve images in Moden Formats
+# Serve images in moden formats
 
 ## Description
 

--- a/docs/guide/initial-reviewer-guide.md
+++ b/docs/guide/initial-reviewer-guide.md
@@ -11,7 +11,11 @@ Does this pattern align to the mission of the Green Software Foundation of reduc
 ### Alignment to Green Software Pattern Template
 Does this pattern align to the [Pattern Template](https://github.com/Green-Software-Foundation/green-software-patterns/blob/dev/TEMPLATE.md) for Green Software Patterns? This includes all sections being present, tags supported on our [Tags list](https://patterns.greensoftware.foundation/tags/), valid author and github alias, clearly defined assumptions and considerations, relevance to SCI has been called out. The Pattern Title should follow the form of a specific `Action` on a specific `Resource`. For example, "Write efficient code" is not a good title since there is no specific action to take on a specific resource. A title of "Cache Static Data"  provides a specific action of Caching to a specific resource of Static Data.
 
-Our documentation system uses "front matter" which requires a specific format for metadata and this section should be included at the top of each submitted pattern. The front matter content and structure can be seen on the [Pattern Template](https://github.com/Green-Software-Foundation/green-software-patterns/blob/dev/TEMPLATE.md) and should include all fields listed there. 
+### Proper Green Software Pattern Formatting
+Our documentation system uses "front matter" which requires a specific format for metadata and this section should be included at the top of each submitted pattern. The front matter content and structure can be seen on the [Pattern Template](https://github.com/Green-Software-Foundation/green-software-patterns/blob/dev/TEMPLATE.md) and should include all fields listed there.
+
+Additionally, we look for patterns to align to the following formatting rules:
+- Titles should be in sentence casing. Ex: `Title of a pattern` and not `Title Of A Pattern`
 
 ### Pull Request Set To Merge In Dev Branch
 We require that all new patterns are submitted against the `dev` branch in the repository. If the pull request is set to merge to any other branch of the repository, the submitter should update it to merge to `dev`.


### PR DESCRIPTION
Updating all pattern titles to follow Sentence casing standards instead of Title Casing Standards (issue #133 ).  Also ensured that all SCI equation sections are being displayed properly and consistently with formatting and a shortened version of the link (issue #134 )   